### PR TITLE
changed "pred" to "predict" to match expected type

### DIFF
--- a/astrospice/net/reg.py
+++ b/astrospice/net/reg.py
@@ -99,7 +99,7 @@ class KernelRegistry:
         body : str
             Spacecraft body.
         type : str
-            ``'recon'`` or ``'pred'`` to downloaded reconstructed or predicted
+            ``'recon'`` or ``'predict'`` to downloaded reconstructed or predicted
             kernels respectively.
         version : int, optional
             If given, get only kernels with this version.


### PR DESCRIPTION
The doctsring for get_kernels() says that the type should be 'recon' or 'pred', but the dictionary is expecting 'predict'.