### PR TITLE
Add metakernel

### DIFF
--- a/astrospice/kernel.py
+++ b/astrospice/kernel.py
@@ -172,10 +172,6 @@ class MetaKernel(KernelBase):
         
         return kernels
     
-    def get_kernel_fname(self, fname):
-        split_fname = fname.split('/')
-        return split_fname[1], split_fname[2]
-    
     def load_kernels(self):
         """
         Loads the kernels specified by the metakernel

--- a/astrospice/kernel.py
+++ b/astrospice/kernel.py
@@ -102,3 +102,101 @@ class SPKKernel(KernelBase):
         body = Body(body)
         coverage = [t for t in spiceypy.spkcov(self._fname_str, body.id)]
         return Time(coverage, format='et').utc
+
+class MetaKernel(KernelBase):
+    """
+    A class for a single .tm kernel.
+
+    References
+    ----------
+    https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html#Additional%20Meta-kernel%20Specifications
+    """
+    _file_extension = '.tm'
+    
+    def __init__(self, fname):
+        self._fname = fname
+        self.change_path_value()
+        if self.kernels_exist:
+            self.load_kernels()
+        else:
+            print("Kernels are not yet loaded")
+        
+    def change_path_value(self):
+        """
+        Changes the PATH_VALUES parameter in the .tm file
+        to point to the same folder as the .tm file.
+        """
+        #open the file
+        with open(self.fname, 'r') as file:
+            # read a list of lines into data
+            data = file.readlines()
+
+        #find the line with PATH_VALUES = ( '..' )
+        for i, line in enumerate(data):
+            line_split = line.split()
+            if len(line_split) > 1 and line_split[0] == 'PATH_VALUES':
+                if line_split[-2] == "'..'":
+                    #replace the ".." with the folder path
+                    data[i] = data[i].replace('..', str(self.fname.parent))
+        
+        #write over the original file
+        with open(self.fname, 'w') as file:
+            file.writelines( data )
+            
+    @property
+    def kernels(self):
+        "List of kernels specified by the metakernel"
+        kernels = []
+        with open(self.fname, "r") as file:
+            look_for_kernels = False
+            for  line in file:
+                #split by whitespace
+                line_split = line.split()
+                
+                # now find the ) bracket by itself, this is the end of kernels to load
+                if len(line_split) >= 1 and line_split[0] == ')':
+                    look_for_kernels = False
+                    break
+                
+                if look_for_kernels == True and len(line_split) > 0:
+                    # find the filename for the kernel. 
+                    # The slicing removes the $KERNEL and the final '
+                    kernel_fname = line_split[0][9:-1]
+                    #do not add empty lines
+                    if kernel_fname != '':
+                        #slice removes the first \
+                        kernels.append(kernel_fname[1:])
+                
+                if len(line_split) > 1 and line_split[0] == 'KERNELS_TO_LOAD':
+                    look_for_kernels = True
+        
+        return kernels
+    
+    def get_kernel_fname(self, fname):
+        split_fname = fname.split('/')
+        return split_fname[1], split_fname[2]
+    
+    def load_kernels(self):
+        """
+        Loads the kernels specified by the metakernel
+        """
+        for kernel in self.kernels:
+            try:
+                Kernel(self.fname.parent / Path(kernel))
+            except ValueError:
+                print(f"Filetype {Path(kernel).suffix} not supported yet\n")
+                
+    def kernels_exist(self):
+        """
+        Checks if the kernels in the metakernel exist
+
+        Returns
+        -------
+        Bool
+            True if all kernels exist, False if not
+        """
+        for kernel in self.kernels:
+            kernel_path = self.fname.parent / Path(kernel)
+            if not kernel_path.exists:
+                return False
+        return True


### PR DESCRIPTION
Added `MetaKernel` class to kernel.py with:
1. `kernels` attribute 
2. `load_kernels()` method
3. `kernels_exist()` method to check if all kernels exist before loading
4. `change_path_value()` method which alters the metakernel file so it points to the same folder it is placed

I added a try statement to catch file types that are not supported by astrospice yet.