### PR TITLE
moved changes from solo-metakernels

### DIFF
--- a/astrospice/kernel.py
+++ b/astrospice/kernel.py
@@ -1,6 +1,8 @@
+import abc
 import logging
 from pathlib import Path
 
+import parfive
 import spiceypy
 from astropy.time import Time
 
@@ -130,6 +132,14 @@ class MetaKernel(KernelBase):
             Path to the metakernel file.
         """
         self._fname = fname
+        if not self.all_kernels_exist:
+            # try and download the kernels
+            print("Downloading Kernels")
+            try:
+                self.download_kernels()
+            except NotImplementedError:
+                # if haven't defined the child class yet, then it just passes
+                pass
         if self.all_kernels_exist:
             self.load_kernels()
         else:
@@ -167,6 +177,49 @@ class MetaKernel(KernelBase):
                 if len(line_split) > 1 and line_split[0] == 'KERNELS_TO_LOAD':
                     look_for_kernels = True
         return kernels
+
+    @abc.abstractproperty
+    def base_url(self):
+        """
+        The url to get the kernels from. This should be an abstract method
+        that is specified by each child metakernel class for each spacecraft.
+        """
+        raise NotImplementedError
+
+    @abc.abstractproperty
+    def mk_folder(self):
+        """
+        The folder to store the metakernel in. Need to have separate folders for
+        different spacecraft.
+        """
+        raise NotImplementedError
+
+    @property
+    def kernel_urls(self):
+        """
+        The kernel urls specified by the metakernel
+        Returns
+        -------
+        kernels : list of kernel urls
+        """
+        urls = []
+        for fname in self.kernels:
+            # get the folder and fname e.g. spk/kernel_name.bsp
+            folder_and_fname = fname.parts[-2] + "/" + fname.name
+            url = self.base_url + folder_and_fname
+            urls.append(url)
+
+        return urls
+
+    def download_kernels(self):
+        """
+        Downloads the kernels specified in the metakernel
+        """
+        dl = parfive.Downloader(file_progress=False)
+        for url, kernel_path in zip(self.kernel_urls, self.kernels):
+            if not kernel_path.exists():
+                dl.enqueue_file(url, kernel_path.parent, kernel_path.name)
+        dl.download()
 
     def load_kernels(self):
         """

--- a/astrospice/net/reg.py
+++ b/astrospice/net/reg.py
@@ -166,7 +166,7 @@ class RemoteKernel:
 class RemoteKernelsBase(abc.ABC):
     def __init_subclass__(cls):
         registry._kernels[cls.body][cls.type] = cls()
-        assert cls.type in ['predict', 'recon']
+        assert cls.type in ['predict', 'recon', 'meta']
 
     def get_latest_kernel(self):
         """
@@ -214,8 +214,9 @@ class RemoteKernelsBase(abc.ABC):
                 msg += f', version={version}'
             raise ValueError(msg)
 
-        if self.type == 'predict':
+        if self.type == 'predict' or self.type =='meta':
             # Only get the most recent version
+            # should this not be get_latest_kernel()? or at least sorted(kernels)[-1]
             kernels = [max(kernels)]
         dl = parfive.Downloader()
         for k in kernels:

--- a/astrospice/net/sources/solo.py
+++ b/astrospice/net/sources/solo.py
@@ -3,9 +3,12 @@ from urllib.request import urlopen
 from astropy.time import Time
 from bs4 import BeautifulSoup
 
+from astrospice.kernel import MetaKernel
 from astrospice.net.reg import RemoteKernel, RemoteKernelsBase
 
 __all__ = ['SolarOrbiterPredict']
+
+SOLO_URL = "http://spiftp.esac.esa.int/data/SPICE/SOLAR-ORBITER/kernels/"
 
 
 class SolarOrbiterPredict(RemoteKernelsBase):
@@ -60,3 +63,75 @@ class SolarOrbiterPredict(RemoteKernelsBase):
         end_time = Time.strptime(times[1], '%Y%m%d')
         version = int(fname[4][1:])
         return True, start_time, end_time, version
+
+
+class SolarOrbiterMetaKernel(MetaKernel):
+
+    @property
+    def base_url(self):
+        """url for Solar Orbiter Kernels"""
+        return SOLO_URL
+
+    @property
+    def mk_folder(self):
+        """folder name for Solar Orbiter Kernels"""
+        return 'solar orbiter'
+
+
+class SolarOrbiterRemoteMetakernel(RemoteKernelsBase):
+    """Will load the metakernel and all the subsequent kernels listed.
+    To start with I will just give it a local path to the metakernel.
+    """
+    body = 'solar orbiter'
+    type = 'meta'
+
+    def get_remote_kernels(self):
+        """
+        This is the same as SolarOrbiterPredict except the url is a different folder and the filetype is different. So we could make this an abstract method, or use a factory?
+        For now I have just done it like this
+        Returns
+        -------
+        list[RemoteKernel]
+        """
+        base_url = SOLO_URL + 'mk'
+        page = urlopen(base_url)
+        soup = BeautifulSoup(page, 'html.parser')
+
+        kernel_urls = []
+        for link in soup.find_all('a'):
+            href = link.get('href')
+            if href is not None and href.endswith('.tm'):
+                fname = href.split('/')[-1]
+                matches = self.matches(fname)
+                if matches:
+                    kernel_urls.append(
+                        RemoteKernel(f'{base_url}/{fname}',
+                                     *matches[1:]))
+
+        return kernel_urls
+
+    @staticmethod
+    def matches(fname):
+        """
+        Check if the given filename matches the pattern of this kernel.
+        Returns
+        -------
+        matches : bool
+        start_time : astropy.time.Time
+        end_time : astropy.time.Time
+        version : int
+        """
+        # Example filename: solo_ANC_soc-flown-mk_V106_20201216_001.tm
+        fname = fname.split('_')
+        if (len(fname) != 6 or
+                fname[0] != 'solo' or
+                fname[1] != 'ANC' or
+                fname[2] != 'soc-flown-mk' and
+                fname[2] != 'soc-pred-mk'):
+            return False
+
+        time = fname[4]
+        time = Time.strptime(time, '%Y%m%d')
+        version = int(fname[3][1:])
+        # metakernels only have one time, but RemoteKernelsBase expects an endtime too
+        return True, time, time, version


### PR DESCRIPTION
As suggested in #8, I have moved the changes to a new PR.

I have made the following changes:

1. MetaKernel can now download the kernels it specifies and save them in the right folder structure. This happens when the class is initiated. 
2. For this to work, I had to make two abstract properties base_url and mk_folder. I thought it would be wise to separate different spacecraft kernels, since they will use the same folder names e.g. "/spk"
3. SolarOrbiterRemoteMetakernel is now a child of RemoteKernelsBase. This can download the "latest" remote metakernel and return a MetaKernel object, that then downloads all the other kernels. However, this class decides the latest kernel by version number. This does not work for metakernels, since they are ordered by time. Also, I would like to specify where the metakernel is saved to (i.e. in a "solar orbiter" folder so we can separate spacecraft).

I am not sure how you would like to proceed with the final point? Should we make the sorting of the kernels an abstract method?

Let me know your thoughts!